### PR TITLE
Build multi-arch image during build step

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -30,6 +30,7 @@ jobs:
         uses: docker/build-push-action@ad44023a93711e3deb337508980b4b5e9bcdc5dc
         with:
           context: .
+          platforms: linux/amd64, linux/arm64/v8, linux/arm/v7, linux/arm/v6
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}


### PR DESCRIPTION
I came across an issue attempting to run this on my Raspberry Pi 4 (where my HA stack currently lives) and realised that the image is only built for `amd64`. As a workaround, I have built the image locally on my Pi, but it would be nice to not need to maintain my own fork/build locally :)

This change _should just work™_, as the arch's are all available for the base image you are using:

![image](https://user-images.githubusercontent.com/1998970/209810436-cbb56dbb-84de-405a-809d-6d1c150a829c.png)
