### PR TITLE
Build (but not push!) on pull request

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -3,6 +3,7 @@ name: ha-auto-guest-login
 on:
   push:
     branches: [ "main" ]
+  pull_request:
 
 jobs:
   push_to_registry:
@@ -19,6 +20,7 @@ jobs:
         uses: docker/setup-buildx-action@v2
       
       - name: Log in to Docker Hub
+        if: github.event_name != 'pull_request'
         uses: docker/login-action@f054a8b539a109f9f41c372932f1ae047eff08c9
         with:
           username: ${{ secrets.DOCKER_USERNAME }}
@@ -35,6 +37,6 @@ jobs:
         with:
           context: .
           platforms: linux/amd64, linux/arm64/v8, linux/arm/v7, linux/arm/v6
-          push: true
+          push: ${{ github.event_name != 'pull_request' }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}


### PR DESCRIPTION
Add `pull_request` trigger to the action - which will help catch any build errors before merging to `main`

Two conditionals are added to:
 1) Prevent log in to docker hub (pull request submitter does not have access to the repo secrets)
 2) Prevent the image from being pushed once built.

Merging to `main` will still log in and push as normal